### PR TITLE
修复在与viewPager等滑动控件嵌套使用的过程中，会产生触摸冲突的问题

### DIFF
--- a/library/src/main/java/com/huxq17/swipecardsview/SwipeCardsView.java
+++ b/library/src/main/java/com/huxq17/swipecardsview/SwipeCardsView.java
@@ -237,6 +237,7 @@ public class SwipeCardsView extends LinearLayout {
                 resetViewGroup();
                 if (isTouchTopView(ev) && canMoveCard() && mEnableSwipe) {
                     isTouching = true;
+                    getParent().requestDisallowInterceptTouchEvent(true);
                 }
                 hasTouchTopView = false;
                 mLastY = (int) ev.getRawY();
@@ -270,6 +271,8 @@ public class SwipeCardsView extends LinearLayout {
                     moveTopView(deltaX, deltaY);
                     invalidate();
                     sendCancelEvent();
+                    // tell parent,not intercept this view TouchEvent
+                    getParent().requestDisallowInterceptTouchEvent(true);
                     return true;
                 }
                 break;
@@ -287,6 +290,8 @@ public class SwipeCardsView extends LinearLayout {
 
                 releaseTopView(xvel, yvel);
                 releaseVelocityTracker();
+                // release touEvent
+                getParent().requestDisallowInterceptTouchEvent(false);
 //                invalidate();
                 break;
         }


### PR DESCRIPTION
在dispatchTouchEvent中增加对父控件停止拦截后续触摸时间的方法调用